### PR TITLE
Removes non existing package definition from main class

### DIFF
--- a/jdeserialize/build.xml
+++ b/jdeserialize/build.xml
@@ -21,7 +21,7 @@
             <fileset dir="." includes="build.xml" />
             <fileset dir="." includes="README" />
             <manifest>
-                <attribute name="Main-Class" value="org.unsynchronized.jdeserialize" />
+                <attribute name="Main-Class" value="jdeserialize" />
             </manifest>
         </jar>
     </target>


### PR DESCRIPTION
Default build.sh produces the following error:

```
$ java -jar jdeserialize.jar
Error: Could not find or load main class org.unsynchronized.jdeserialize
```

This change fixes the error.
