### PR TITLE
Fixes for null output and array handling

### DIFF
--- a/jdeserialize/src/arraycoll.java
+++ b/jdeserialize/src/arraycoll.java
@@ -41,7 +41,7 @@ public class arraycoll extends ArrayList<Object> {
             } else {
                 sb.append(", ");
             }
-            sb.append(o.toString());
+            sb.append(o);
         }
         return sb.toString();
     }

--- a/jdeserialize/src/jdeserialize.java
+++ b/jdeserialize/src/jdeserialize.java
@@ -224,8 +224,8 @@ public class jdeserialize {
             case OBJECT:
             case ARRAY:
                 byte stc = dis.readByte();
-                if(f == fieldtype.ARRAY && stc != ObjectStreamConstants.TC_ARRAY) {
-                    throw new IOException("array type listed, but typecode is not TC_ARRAY: " + hex(stc));
+                if(f == fieldtype.ARRAY && (stc != ObjectStreamConstants.TC_ARRAY  && stc != ObjectStreamConstants.TC_NULL && stc != ObjectStreamConstants.TC_REFERENCE)) {
+                    throw new IOException("array type listed, but typecode is not TC_ARRAY|TC_NULL|TC_REFERENCE: " + hex(stc));
                 }
                 content c = read_Content(stc, dis, false);
                 if(c != null && c.isExceptionObject()) {
@@ -626,8 +626,10 @@ public class jdeserialize {
         if(cd.name.length() < 2) {
             throw new IOException("invalid name in array classdesc: " + cd.name);
         }
-        arraycoll ac = read_arrayValues(cd.name.substring(1), dis);
-        return new arrayobj(handle, cd, ac);
+        arrayobj ao = new arrayobj(handle, cd, null);
+        setHandle(handle, ao);
+        ao.data = read_arrayValues(cd.name.substring(1), dis);
+        return ao;
     }
     public arraycoll read_arrayValues(String str, DataInputStream dis) throws IOException {
         byte b = str.getBytes("UTF-8")[0];

--- a/jdeserialize/src/jdeserialize.java
+++ b/jdeserialize/src/jdeserialize.java
@@ -840,7 +840,7 @@ public class jdeserialize {
                     break;
                 }
                 content c = read_Content(tc, dis, true);
-                System.out.println("read: " + c.toString());
+                System.out.println("read: " + c);
                 if(c != null && c.isExceptionObject()) {
                     c = new exceptionstate(c, lis.getRecordedData());
                 }
@@ -918,7 +918,7 @@ public class jdeserialize {
         if(!go.hasOption("-nocontent")) {
             System.out.println("//// BEGIN stream content output");
             for(content c: content) {
-                System.out.println(c.toString());
+                System.out.println(c);
             }
             System.out.println("//// END stream content output");
             System.out.println("");


### PR DESCRIPTION
Fixing these let me process a fairly complex serialized file. It's rather wild it didn't support either null arrays or back-referencing arrays.